### PR TITLE
💪 Rename `ConstructorSpyGenerator` to `ConstructorSpy`

### DIFF
--- a/lib/ConstructorSpy.js
+++ b/lib/ConstructorSpy.js
@@ -1,10 +1,10 @@
 'use strict'
 
-class ConstructorSpyGenerator {
+class ConstructorSpy {
   /**
    * Constructor.
    *
-   * @param {ConstructorSpyGeneratorParams} params - Parameters of constructor.
+   * @param {ConstructorSpyParams} params - Parameters of constructor.
    */
   constructor ({
     jest,
@@ -15,8 +15,8 @@ class ConstructorSpyGenerator {
   /**
    * Factory method.
    *
-   * @param {ConstructorSpyGeneratorParams} params - Parameters of constructor.
-   * @returns {ConstructorSpyGenerator} - Instance of this class.
+   * @param {ConstructorSpyParams} params - Parameters of constructor.
+   * @returns {ConstructorSpy} - Instance of this class.
    */
   static create (params) {
     return new this(params)
@@ -48,12 +48,12 @@ class ConstructorSpyGenerator {
   }
 }
 
-module.exports = ConstructorSpyGenerator
+module.exports = ConstructorSpy
 
 /**
  * @typedef {{
  *   jest: Object,
- * }} ConstructorSpyGeneratorParams
+ * }} ConstructorSpyParams
  */
 
 /**

--- a/tests/__tests__/ConstructorSpy.js
+++ b/tests/__tests__/ConstructorSpy.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const ConstructorSpyGenerator = require('../../lib/ConstructorSpyGenerator')
+const ConstructorSpy = require('../../lib/ConstructorSpy')
 
-describe('ConstructorSpyGenerator', () => {
+describe('ConstructorSpy', () => {
   describe('constructor', () => {
     describe('to keep property', () => {
       test('#jest', () => {
-        const generator = new ConstructorSpyGenerator({ jest })
+        const generator = new ConstructorSpy({ jest })
 
         expect(generator.jest)
           .toBe(jest) // same reference.
@@ -15,19 +15,19 @@ describe('ConstructorSpyGenerator', () => {
   })
 })
 
-describe('ConstructorSpyGenerator', () => {
+describe('ConstructorSpy', () => {
   describe('.create()', () => {
     test('instance of', () => {
-      const generator = ConstructorSpyGenerator.create({ jest })
+      const generator = ConstructorSpy.create({ jest })
 
       expect(generator)
-        .toBeInstanceOf(ConstructorSpyGenerator)
+        .toBeInstanceOf(ConstructorSpy)
     })
 
     test('call constructor', () => {
       const constructorSpy = jest.fn()
 
-      class DerivedClass extends ConstructorSpyGenerator {
+      class DerivedClass extends ConstructorSpy {
         constructor (params) {
           super(params)
 
@@ -45,10 +45,10 @@ describe('ConstructorSpyGenerator', () => {
   })
 })
 
-describe('ConstructorSpyGenerator', () => {
+describe('ConstructorSpy', () => {
   describe('#generateSpyKitClass()', () => {
     describe('spy works', () => {
-      const generator = ConstructorSpyGenerator.create({ jest })
+      const generator = ConstructorSpy.create({ jest })
 
       class Target {
         /**


### PR DESCRIPTION
## Why

* Close #25

## How

* Rename file names concerning `ConstructorSpyGenerator` to `ConstructorSpy`
* Rename declarations `ConstructorSpyGenerator` to `ConstructorSpy` in all files
