### PR TITLE
🦵 Kick out `@openreachtech:registry` from `.npmrc`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@openreachtech:registry=https://npm.pkg.github.com


### PR DESCRIPTION
# Why

* Close #116